### PR TITLE
Add RegExp support and additional path providing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 npm-debug.log
 .env
 coverage.html
+.idea

--- a/index.js
+++ b/index.js
@@ -21,23 +21,42 @@ const Relish = function Relish (opts) {
         message: this._opts.stripQuotes ? i.message.replace(/"/g, '') : i.message,
         type: i.type.split('.').shift(),
         constraint: i.type.split('.').pop()
-      }
+      };
 
       // if label is different than key, provide label
       if (i.context.key !== err.key) {
         err.label = i.context.key
       }
 
-      // set custom message (if exists)
-      if (this._opts.messages.hasOwnProperty(err.path)) {
-        err.message = this._opts.messages[err.path]
-      } else if (this._opts.messages.hasOwnProperty(err.key)) {
-        err.message = this._opts.messages[err.key]
+    // set custom message (if exists)
+    if (this._opts.messages.hasOwnProperty(err.path)) {
+      err.message = this._opts.messages[err.path]
+    } else if (this._opts.messages.hasOwnProperty(err.key)) {
+      err.message = this._opts.messages[err.key];
+    } else {
+      // loop through the messages object to math path using regex
+      for (var msgKey in this._opts.messages) {
+        if (this._opts.messages.hasOwnProperty(msgKey)) {
+          // regexObj is a cached object that contains {path: RegExp} pair
+          this._opts.regexObj = this._opts.regexObj || {};
+          // Check if we have a RegExp for this path
+          // otherwise create a RegExp and cache it
+          this._opts.regexObj[msgKey] = this._opts.regexObj[msgKey] || this.strToRegExp(msgKey);
+          // if path matches with RegExp
+          if (err.path.match(this._opts.regexObj[msgKey])) {
+            err.message = this._opts.messages[msgKey];
+          }
+        }
       }
+    }
+    // Overwrite error message with constraint specific error message
+    err.message = err.message[err.constraint] || err.message['default'] || err.message;
+    // Adding interaction number if present
+    err.path = this.addPath(err.path, error);
 
-      return err
-    })
-  }
+    return err;
+  })
+  };
 
   this.formatResponse = (error, source, errorMessage, errors) => {
     // append errors array to response
@@ -48,26 +67,59 @@ const Relish = function Relish (opts) {
     }
 
     return error
-  }
+  };
 
   this.exports.options = (opts) => {
     this._opts = Hoek.applyToDefaults(this._opts, opts)
 
     return this.exports
-  }
+  };
 
   this.exports.failAction = (request, reply, source, error) => {
+
     // parse error object
-    const errors = this.parseError(error)
+    const errors = this.parseError(error);
 
     // build main error message
-    const errorMessage = errors.map((e) => e.message).join(', ')
+    const errorMessage = errors.map((e) => JSON.stringify(e.message)).join(', ');
 
     // format error response
-    error = this.formatResponse(error, source, errorMessage, errors)
+    error = this.formatResponse(error, source, errorMessage, errors);
 
     return reply(error)
-  }
+  };
+  /**
+   * Converts a string into a RegExp
+   * Adds ^ before path and $ at the end if not present
+   * @param {string} str
+   * @returns {RegExp}
+   */
+  this.strToRegExp = function (str) {
+
+    //Add ^ in beginning if not present
+    if (!str.startsWith('^')) {
+      str = '^' + str;
+    }
+    //Add $ in end if not present
+    if (!str.endsWith('$')) {
+      str = str + '$';
+    }
+
+    return new RegExp(str);
+  };
+  /**
+   * Concatenates provided path with the error path
+   * @param errorPath
+   * @param error
+   * @returns errorPath
+   */
+  this.addPath = function (errorPath, error) {
+
+    if (error.data.path) {
+      errorPath = error.data.path + '.' + errorPath;
+    }
+    return errorPath;
+  };
 
   return this.exports
 }


### PR DESCRIPTION
I have added following feature.

- Now custom messages can be provided to match RegExp. Like if the payload contains array or dynamic property, we will be able to match them using RegExp.

Example:

```
{
  "([0-9]+.)?feedeedback.(correct|wrong).title(.+)?": "My Message"
}
```

- Messages can be constraint based.

Example:
```
{
  "([0-9]+.)?feedeedback.(correct|wrong).title(.+)?": {
    "default": "Default error message",
    "required": "Message based on required constraint"
  }
}
```

- Can provide additional path to trace the error more accurately. This path must be provide in Joi error when we use internal validation using **`Joi.validate()`**. Please see following two snippets. First one is Joi error with extended path injected and second one is returned by Relish.


```
{
  "isJoi": true,
  "name": "ValidationError",
  "details": [
    {
      "message": "\"point\" must be a number",
      "path": "pointRanges.1.point",
      "type": "number.base",
      "context": {
        "key": "point"
      }
    }
  ]
  "path": "0.itemBody.interactions.readingInteraction"
}
```

```
[
  {
    "statusCode": 400,
    "error": "Bad Request",
    "message": "{\"en\":\"point must be a number\"}",
    "validation": {
      "source": "payload",
      "errors": [
        {
          "key": "point",
          "path": "0.itemBody.interactions.readingInteraction.pointRanges.1.point",
          "message": {
            "en": "point must be a number"
          },
          "type": "number",
          "constraint": "base"
        }
      ]
    }
  }
]
```